### PR TITLE
Fix swapped preference arrays

### DIFF
--- a/app/src/main/java/org/n0/speedy_launch/MainActivity.java
+++ b/app/src/main/java/org/n0/speedy_launch/MainActivity.java
@@ -85,8 +85,8 @@ public class MainActivity extends Activity {
         /* array adapter which will be used to populate the main list */
         appAdapter = new ArrayAdapter<>(this, R.layout.main_listview, R.id.mnTxtVw, new ArrayList<>());
 
-        ArrayAdapter<String> leftPrefsAdapter = new ArrayAdapter<>(this, R.layout.main_listview, R.id.mnTxtVw, rightPrefsArr);
-        ArrayAdapter<String> rightPrefsAdapter = new ArrayAdapter<>(this, R.layout.main_listview, R.id.mnTxtVw, leftPrefsArr);
+        ArrayAdapter<String> leftPrefsAdapter = new ArrayAdapter<>(this, R.layout.main_listview, R.id.mnTxtVw, leftPrefsArr);
+        ArrayAdapter<String> rightPrefsAdapter = new ArrayAdapter<>(this, R.layout.main_listview, R.id.mnTxtVw, rightPrefsArr);
 
 
         leftPrefsListView.setAdapter(leftPrefsAdapter);


### PR DESCRIPTION
## Summary
- Correct left/right preference adapters to use the proper symbol arrays

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68aeee1a7918832ba001f6670f8787c1